### PR TITLE
Fix: setState after await without mounted check + ValueNotifier leaks

### DIFF
--- a/src/lib/dialogs/settings_dialog.dart
+++ b/src/lib/dialogs/settings_dialog.dart
@@ -1023,6 +1023,7 @@ class _SettingsDialogState extends State<SettingsDialog>
       ),
     );
     if (result != null) {
+      if (!mounted) return;
       setState(() => _settings.aprsRoutes.add(result));
     }
   }
@@ -1039,6 +1040,7 @@ class _SettingsDialogState extends State<SettingsDialog>
       ),
     );
     if (result != null) {
+      if (!mounted) return;
       setState(() => _settings.aprsRoutes[index] = result);
     }
   }

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -2424,6 +2424,7 @@ class _MainFormState extends State<MainForm>
       _statusText = '';
     });
 
+    if (!mounted) return;
     await RadioConnectionDialog.show(context, compatibleDevices);
   }
 
@@ -2577,6 +2578,7 @@ class _MainFormState extends State<MainForm>
       // Settings were saved to DataBroker
       // Reload settings to update UI
       _loadSettingsFromBroker();
+      if (!mounted) return;
       setState(() {});
     }
   }

--- a/src/lib/widgets/map_tab.dart
+++ b/src/lib/widgets/map_tab.dart
@@ -1185,6 +1185,8 @@ class _MapTabState extends State<MapTab> with AutomaticKeepAliveClientMixin {
       onProgress: (done, total) => progressNotifier.value = (done, total),
       cancel: cancelNotifier,
     ).then((_) {
+      progressNotifier.dispose();
+      cancelNotifier.dispose();
       if (mounted && Navigator.of(context).canPop()) {
         Navigator.of(context).pop(); // dismiss progress dialog
       }


### PR DESCRIPTION
## Summary

Fixes several bugs found during code review:

1. **`main.dart` - `_onSettings()`**: `setState(() {})` called after `await showDialog()` without `mounted` check. Can cause `setState() called after dispose()` if widget is unmounted while dialog is open.

2. **`main.dart` - `_onConnect()`**: `BuildContext` used in `RadioConnectionDialog.show(context, ...)` after `await findCompatibleDevices()` without `mounted` check. Can cause "looking up a deactivated widget's ancestor" errors.

3. **`settings_dialog.dart` - `_addAprsRoute()` and `_editAprsRoute()`**: Both call `setState` after `await showDialog()` without `mounted` check.

4. **`map_tab.dart` - `_downloadCacheArea()`**: `progressNotifier` and `cancelNotifier` (ValueNotifiers) are never disposed, causing memory leaks on each cache download.

## Type of change
- [x] Bug fix (non-breaking)

## Testing
- Code review confirmed all 4 locations are missing safety checks
- Fixes are minimal: `if (!mounted) return;` guards and `.dispose()` calls
- No behavioral changes for normal use cases

## Related issue
Closes #7