### PR TITLE
Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/src"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dart"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with:

- **Pub packages**: weekly checks, groups patch/minor into single PRs, major bumps as separate PRs
- **GitHub Actions**: weekly checks for action version updates

## Type of change
- [x] New feature (non-breaking automation addition)

## Testing
- Validated YAML syntax

## Related issue
Closes #4