### PR TITLE
Add PR template, issue templates, and SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: ["bug"]
+---
+
+## Description
+
+<!-- Clear description of the bug -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen -->
+
+## Actual behavior
+
+<!-- What actually happened -->
+
+## Environment
+
+- **Radio model**: <!-- UV-Pro / GA-5WB / VR-N76 / VR-N7500 / VR-N7600 -->
+- **OS**: <!-- Windows / macOS / Linux / Android / iOS / Web -->
+- **App version**: <!-- e.g. v0.1.5 -->
+- **Connection**: <!-- USB / Bluetooth / TCP / UDP -->
+
+## Logs / screenshots
+
+<!-- Paste any relevant logs or screenshots -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: ["enhancement"]
+---
+
+## Problem
+
+<!-- What problem does this feature solve? -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to see -->
+
+## Alternatives considered
+
+<!-- Any alternative approaches you've thought about -->
+
+## Additional context
+
+<!-- Screenshots, mockups, links, etc. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in HTCommander, please report it responsibly.
+
+### How to report
+
+1. **Preferred**: Use [GitHub Security Advisories](https://github.com/Ylianst/HTCommander/security/advisories/new) to report privately
+2. **Alternative**: Email the maintainer directly
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response time
+
+You can expect an initial response within 72 hours.
+
+## Scope
+
+The latest release is supported. Please test against the current release before reporting.
+
+## Out of scope
+
+- Vulnerabilities in third-party dependencies (report to the dependency maintainer)
+- Issues that require physical access to the radio hardware
+- Social engineering attacks

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation
+- [ ] Refactor / cleanup
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Testing
+
+- [ ] Code compiles without errors
+- [ ] `dart analyze` passes
+- [ ] `dart format` passes
+- [ ] Manually tested on (radio model / platform):
+
+## Related issues
+
+<!-- Link any related issues: Closes #N -->


### PR DESCRIPTION
## Summary

Adds contributor templates and a security policy:

- **`.github/pull_request_template.md`**: Structured PR descriptions with type, changes, testing checklist, and related issues
- **`.github/ISSUE_TEMPLATE/bug_report.md`**: Guided bug reports including radio model, OS, app version, and connection type
- **`.github/ISSUE_TEMPLATE/feature_request.md`**: Structured feature requests with problem/solution/alternatives
- **`.github/SECURITY.md`**: Responsible vulnerability disclosure policy with GitHub Security Advisories as preferred method

## Type of change
- [x] Documentation / community

## Testing
- Validated all markdown syntax
- Issue templates use correct YAML frontmatter for automatic label assignment

## Related issues
Closes #5, closes #6